### PR TITLE
Added naive https support

### DIFF
--- a/couchquery/__init__.py
+++ b/couchquery/__init__.py
@@ -75,8 +75,9 @@ class Httplib2Client(HttpClient):
 
         if http_override is None:
             if '@' in self.uri:
-                user, password = self.uri.replace('http://','').split('@')[0].split(':')
-                self.uri = 'http://'+self.uri.split('@')[1]
+                protocol = 'https://' if 'https' in self.uri else 'http://'
+                user, password = self.uri.replace(protocol,'').split('@')[0].split(':')
+                self.uri = protocol+self.uri.split('@')[1]
                 if cache is None:
                     cache = '.cache'
                 self.http = httplib2.Http(cache)


### PR DESCRIPTION
Removed where 'http://' is hardcoded. This way couchquery can be used on Cloudant and other HTTPS-based CouchDB hosts.
