### PR TITLE
Workaround on coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 *~
 
+.coverage
+
 env/
 build/
 couchquery.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - couchdb
 
 # command to run tests
-script: nosetests --with-coverage
+script: nosetests --with-coverage --cover-package=couchquery
 
 after_success:
   coveralls


### PR DESCRIPTION
Now coveralls is not including all the unnecessary third party module into the coverage analysis.
